### PR TITLE
Fix Executable_Trait compatibility with handle() and execute_now()

### DIFF
--- a/src/Foundation/Support/Executable_Trait.php
+++ b/src/Foundation/Support/Executable_Trait.php
@@ -6,8 +6,16 @@ namespace Yivic_Base\Foundation\Support;
 
 trait Executable_Trait {
 	public static function exec( ...$arguments ) {
-		$command = new static( ...$arguments );
+		$command    = new static( ...$arguments );
+		$method     = method_exists( $command, 'execute' ) ? 'execute' : 'handle';
 
-		return app()->call( [ $command, 'execute' ] );
+		return app()->call( [ $command, $method ] );
+	}
+
+	public static function execute_now( ...$arguments ) {
+		$command    = new static( ...$arguments );
+		$method     = method_exists( $command, 'handle' ) ? 'handle' : 'execute';
+
+		return app()->call( [ $command, $method ] );
 	}
 }


### PR DESCRIPTION
### What this PR does

This PR improves `Executable_Trait` to be more robust and backward-compatible.

- Allows `exec()` to call `handle()` automatically when `execute()` is not defined
- Adds `execute_now()` as a first-class alias for immediate execution
- Keeps existing behavior fully intact for classes already defining `execute()`

### Why this is needed

Some jobs only implement `handle()`, while others expect `execute()` or `execute_now()`.
This change ensures all supported conventions work consistently without requiring
boilerplate methods in every job class.

### Backward compatibility

✅ No breaking changes  
✅ Existing jobs continue to work as before
