### PR TITLE
Fix wp_app() helper and correct wp-app config path resolution

### DIFF
--- a/src/App/WP/WP_Application.php
+++ b/src/App/WP/WP_Application.php
@@ -55,8 +55,8 @@ class WP_Application extends Application {
 			App_Const::FILTER_WP_APP_PREPARE_CONFIG,
 			[
 				'app'         => require_once dirname(
-						dirname( dirname( __DIR__ ) )
-					) . DIR_SEP . 'wp-app-config' . DIR_SEP . 'app.php',
+					dirname( dirname( __DIR__ ) )
+				) . DIR_SEP . 'wp-app-config' . DIR_SEP . 'app.php',
 				'wp_app_slug' => YIVIC_BASE_WP_APP_PREFIX,
 				'wp_api_slug' => YIVIC_BASE_WP_API_PREFIX,
 			]

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,9 +3,30 @@
 declare(strict_types=1);
 
 use Yivic_Base\App\Support\Yivic_Base_Helper;
+use Yivic_Base\App\WP\WP_Application;
 
 if ( ! function_exists( 'yivic_base_wp_app_web_page_title' ) ) {
 	function yivic_base_wp_app_web_page_title() {
 		return Yivic_Base_Helper::wp_app_web_page_title();
+	}
+}
+
+if ( ! function_exists( 'wp_app' ) ) {
+	/**
+	 * Get the available container instance.
+	 *
+	 * @param  ?string  $abstract
+	 * @param  array    $parameters
+	 * @return mixed|WP_Application
+	 */
+	// phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.abstractFound
+	function wp_app( ?string $abstract = null, array $parameters = [] ): mixed {
+		$app = WP_Application::getInstance();
+
+		if ( $abstract === null ) {
+			return $app;
+		}
+
+		return $app->make( $abstract, $parameters );
 	}
 }


### PR DESCRIPTION
This PR adds a global `wp_app()` helper for accessing the `WP_Application`
container and fixes the path resolution for loading `wp-app-config/app.php`.

These changes improve compatibility with plugins that rely on `wp_app()`
and ensure the application config is loaded from the correct base directory.
